### PR TITLE
Potsdam Blitz Submission

### DIFF
--- a/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
+++ b/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-4*4-700-t0.0</th>
+      <td>14.39</td>
+      <td>34.79</td>
+      <td>41.35</td>
+      <td>25.38</td>
+      <td>21.21</td>
+      <td>41.51</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>84.0</td>
+      <td>62.0</td>
+      <td>17.31</td>
+      <td>33.33</td>
+      <td>59.48</td>
+      <td>21.71</td>
+      <td>100.0</td>
+      <td>23.33</td>
+      <td>43.02</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>40.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>100.0</td>
+      <td>36.67</td>
+      <td>48.46</td>
+      <td>60.0</td>
+      <td>19.91</td>
+      <td>36.04</td>
+      <td>2.0</td>
+      <td>60.0</td>
+      <td>NaN</td>
+      <td>6.67</td>
+      <td>38.89</td>
+      <td>7.86</td>
+      <td>40.0</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
Potsdam Blitz Team: Arefeva, Tsiakalou, Zarev, Zorin

Our Model:
- Model: LLaMA 3.1 8B Instruct 4-bit tuned with unsloth and DPO
- Dataset: allenai/tulu-3-pref-personas-instruction-following
- Batch size: 4×4, steps: 700
- Results: clemscore 14.39, Avg % Played 34.79, Avg Quality Score 41.35

The Baseline (Llama3-8b-it-4bit): clemscore 19.58, Avg % Played 49.43, Avg Quality Score 39.62

Experiments Description:
We focus on whether improving a model's general abilities - including instruction-following, conversational capabilities, and broader preference tuning - can lead to better performance in interactive, game-like environments, even without exposing the model to game-specific data. We apply several tuning strategies, including instruction-following datasets, real-world conversational data (WildChat), and mixture preference datasets.

Repository link (shared by both teams):
https://github.com/paulutsch/pm-25