### PR TITLE
add fixed clemscore for base model

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ For this beta-testing round, we can't offer any cash prizes, or much of anything
 
 | Rank | Submission Name | Date | Team Name | clemscore | statscore | Short Description |
 | ---------- | ------- | ------- | ------- | -------|------|-----|
-| 1 | Meta-Llama-3.1-8B-Instruct (base) | 2025-07-03 | OrgTeam | 21.49 | tba | The unmodified base model |
+| 1 | Llama-3.1-8B-Instruct (base) | 2025-07-03 | OrgTeam | 24.60      | tba | The unmodified base model |
 | 2 |  Llama-3.1-8B-It-4bit (base) | 2025-07-03 | Team Potzblitz | 19.58 | tba | The base model, 4bit quantized |
-| 3 | Llama-3.1-8B-PotsBlitz-1 | 2025-07-03 | Team Potsblitz | 14.39 | tba | tba 
+| 3 | Llama-3.1-8B-PotsBlitz-1 | 2025-07-03 | Team Potsblitz | 14.39 | tba | tba |
 
 Here's how the sorting works (will eventually work): Entries will be sorted by clemscore (higher is better), but only those entries will enter the sorting that have a statscore that is not lower than that of the baseline agent. (This is to ensure that your agent does not regress on other desirable properties measured by the static benchmarking pipeline. (And no, obviously you may not add any of that test data to your training data.))
 


### PR DESCRIPTION
There was a problem that clembench games were not correctly annotated with the benchmark 2.0 tag. 
In addition, wordle variants used the from instances file.